### PR TITLE
Build with sample-go-multiarch

### DIFF
--- a/ko/build-with-ko.sh
+++ b/ko/build-with-ko.sh
@@ -2,54 +2,25 @@
 
 set -eu -o pipefail
 
-IMAGE_REPO="${IMAGE_REPO:-quay.io/adambkaplan/shipwright-io}"
-TAG="${TAG:-2024-devconf-us}"
+IMAGE_REPO="${IMAGE_REPO:-quay.io/adambkaplan/sample-go-multiarch}"
+VERSION="${VERSION:-0.1.0-devconf-us}"
 PLATFORM="${PLATFORM:-all}"
-TMPDIR="${TMPDIR:-/tmp/build-with-ko}"
 PODMAN="${PODMAN:-podman}"
 
 source ../lib/demo-magic.sh
 
-rm -rf "${TMPDIR}"
-mkdir -p "${TMPDIR}"
-
-pushd ~/go/src/github.com/shipwright-io/build > /dev/null
+pushd ~/go/src/github.com/adambkaplan/sample-go-multiarch > /dev/null
 
 clear
 
-p "Ko is a tool for building and deploying Go applications."
-p "It is specialized for Go, and uses the SDK's cross-platform compiler to build multi-arch images."
-p "Let's use ko to make images for the Shipwright Build project!"
+p "Let's use ko to make a container image!"
 
-pe "pwd && ls"
-
-pe "ko \
-version"
-
-wait
-clear
-
-p "Let's build!"
-
-cmd
-
-# Run ko resolve these commands
-# KO_DOCKER_REPO="${IMAGE_REPO}" ko resolve \
-#   --base-import-paths \
-#   --recursive \
-#   --tags "${TAG}" \
-#   --platform "${PLATFORM}" \
-#   --filename deploy/ > "${TMPDIR}/release.yaml"
+pe "pwd && tree"
+pe "make ko-build VERSION=${VERSION} PLATFORMS=${PLATFORM} IMAGE_TAG_BASE=${IMAGE_REPO}"
 
 popd > /dev/null
 
-p "The build is now complete, and we have a YAML manifest that can be deployed on Kubernetes."
-wait
-clear
-
-p "Let's look at the digests that were produced."
-pe "grep ${IMAGE_REPO} ${TMPDIR}/release.yaml"
-p "And if we inspect the manifest, we see the individual images."
-pe "${PODMAN} manifest inspect ${IMAGE_REPO}/shipwright-build-controller:${TAG}"
+p "Let's inspect the manifest with podman"
+pe "${PODMAN} manifest inspect ${IMAGE_REPO}:v${VERSION}"
 
 p "Voila! A manifest list with our multi-arch Go application!"


### PR DESCRIPTION
Switch from using Shipwright to a sample go application. This app will be used in a subsequent demo for mult-arch builds on Kubernetes. Since this sample uses Helm to deploy, we can't use `ko resolve` easily. The sample instead has Makefile targets which simplify the build and deploy on a cluster.